### PR TITLE
feat(all): adjusted package configurations, and added support for management via lerna lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ this is far from packed for re-use, but if you insist, the main dependencies sho
 
 ## running
 
+install LTS versions of [npm](https://www.npmjs.com/) and [node.js](https://nodejs.org/en/)
+
+now run these commands inside the poly-bool-comparison directory
+```
+npm install
+npm run setup
+```
+
 to re-run everything try running `./run`... good luck ;)
 
 to update a single algorithm run `./run <dirname>`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ martinez_{[cgal](https://github.com/daef/poly-bool-comparison/tree/master/martin
 
 this is far from packed for re-use, but if you insist, the main dependencies should be node, graphicsmagick and inkscape
 
+graphicsmagick can be downloaded (source) and compiled into a set of command line utilities. See http://www.graphicsmagick.org/README.html
+
+inkscape can be downloaded and installed. See https://inkscape.org
+
 ## running
 
 install LTS versions of [npm](https://www.npmjs.com/) and [node.js](https://nodejs.org/en/)

--- a/dissection/package.json
+++ b/dissection/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "dissection",
+  "version": "1.0.0",
+  "description": "Quick webserver for debugging",
+  "scripts": {
+    "setup": "npm install && npm run create-links",
+    "clean": "rm ./magick ./martinez_cgal ./martinez_cpp ./milevski ./pathkit ./rust-geo-booleanop ./unisamples ./voidqk",
+    "create-links": "ln -sf ../magick && ln -sf ../martinez_cgal && ln -sf ../martinez_cpp && ln -sf ../milevski && ln -sf ../pathkit && ln -sf ../rust-geo-booleanop && ln -sf ../unisamples && ln -sf ../voidqk",
+    "dev": "npx http-server"
+  },
+  "dependencies": {
+  }
+}

--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,15 @@
+{
+  "command": {
+    "publish": {
+      "conventionalCommits": true
+    }
+  },
+  "packages": [
+    "dissection",
+    "milevski",
+    "pathkit",
+    "unisamples",
+    "voidqk"
+  ],
+  "version": "0.0.0"
+}

--- a/milevski/package.json
+++ b/milevski/package.json
@@ -1,6 +1,11 @@
 {
-    "dependencies": {
-        "geojson-to-svg": "^1.0.3",
-        "martinez-polygon-clipping": "git+ssh://git@github.com/w8r/martinez.git"
-    }
+  "name": "milevski",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "setup": "npm install"
+  },
+  "dependencies": {
+    "martinez-polygon-clipping": "^0.7.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,22 +2,25 @@
   "name": "poly-bool-comparison",
   "version": "1.0.0",
   "description": "This is a (very hacky) comparison of various polygon clipping algorithms.",
-  "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "setup": "lerna run setup"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/martin19/poly-bool-comparison.git"
+    "url": "git+https://github.com/daef/poly-bool-comparison.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/martin19/poly-bool-comparison/issues"
+    "url": "https://github.com/daef/poly-bool-comparison/issues"
   },
-  "homepage": "https://github.com/martin19/poly-bool-comparison#readme",
+  "homepage": "https://github.com/daef/poly-bool-comparison#readme",
   "dependencies": {
     "express": "^4.17.1",
     "json-stringify-pretty-compact": "^3.0.0"
+  },
+  "devDependencies": {
+    "@lerna-lite/cli": "^1.5.1",
+    "@lerna-lite/run": "^1.5.1"
   }
 }

--- a/pathkit/package.json
+++ b/pathkit/package.json
@@ -2,12 +2,9 @@
   "name": "pathkit",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "setup": "npm install"
   },
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "pathkit-wasm": "^0.7.0"
   }

--- a/voidqk/package.json
+++ b/voidqk/package.json
@@ -1,5 +1,11 @@
 {
-    "dependencies": {
-        "polybooljs": "^1.2.0"
-    }
+  "name": "voidqk",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "setup": "npm install"
+  },
+  "dependencies": {
+    "polybooljs": "^1.2.0"
+  }
 }


### PR DESCRIPTION
Given that there are many sub-packages, I suggest moving to lerna lite for managing each of the packages, which should make it easy to build, and test later.

As a bonus, there's a new package.json for dissection which has several scripts to setup / cleanup linkages to the other sub-packages, and start 'dev' webserver.